### PR TITLE
Add K9 and PUPCUP (World Pup Coin) to Ethereum token list

### DIFF
--- a/lists/token-lists/default-token-list/tokens/ethereum.json
+++ b/lists/token-lists/default-token-list/tokens/ethereum.json
@@ -4118,5 +4118,21 @@
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/token/zrx.jpg",
     "name": "0x",
     "symbol": "ZRX"
+  },
+  {
+    "address": "0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930",
+    "chainId": 1,
+    "decimals": 18,
+    "name": "K9",
+    "symbol": "K9",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930/logo.png"
+  },
+  {
+    "address": "0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef",
+    "chainId": 1,
+    "decimals": 18,
+    "name": "World Pup Coin",
+    "symbol": "PUPCUP",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef/logo.png"
   }
 ]


### PR DESCRIPTION
Adding K9 and PUPCUP (World Pup Coin) ERC20 tokens on Ethereum mainnet.

**K9** — `0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930` — https://dex.clutch.market
**PUPCUP (World Pup Coin)** — `0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef` — https://pupcup.clutch.market/

Both tokens:
- 0% buy/sell tax
- Active Uniswap V4 liquidity
- GoPlus security: clean
- Contract verified on Etherscan