### PR TITLE
Add PUPCUP (Pup Cup) to Base default token list

### DIFF
--- a/lists/token-lists/default-token-list/tokens/base.json
+++ b/lists/token-lists/default-token-list/tokens/base.json
@@ -1,5 +1,21 @@
 [
   {
+    "address": "0x3bB4445D30AC020a84c1b5A8A2C6248ebC9779D0",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0x3bB4445D30AC020a84c1b5A8A2C6248ebC9779D0.jpg",
+    "name": "0x Protocol Token",
+    "symbol": "ZRX"
+  },
+  {
+    "address": "0x7ED613AB8b2b4c6A781DDC97eA98a666c6437511",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x7ED613AB8b2b4c6A781DDC97eA98a666c6437511.jpg",
+    "name": "All Your Base",
+    "symbol": "AYB"
+  },
+  {
     "address": "0x18A8BD1fe17A1BB9FFB39eCD83E9489cfD17a022",
     "chainId": 8453,
     "decimals": 18,
@@ -40,12 +56,12 @@
     "symbol": "axlUSDC"
   },
   {
-    "address": "0x7ED613AB8b2b4c6A781DDC97eA98a666c6437511",
+    "address": "0x09DeB3CF353186E7A84aBfD7434BF643f77eB686",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x7ED613AB8b2b4c6A781DDC97eA98a666c6437511.jpg",
-    "name": "All Your Base",
-    "symbol": "AYB"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0x09DeB3CF353186E7A84aBfD7434BF643f77eB686.jpg",
+    "name": "BASE BOT",
+    "symbol": "BOT"
   },
   {
     "address": "0x7c6b91D9Be155A6Db01f749217d76fF02A7227F2",
@@ -72,6 +88,54 @@
     "symbol": "baldcat"
   },
   {
+    "address": "0x2CcbEcc47D83eE80e27fd09c8e757B82F1fFad4C",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x2CcbEcc47D83eE80e27fd09c8e757B82F1fFad4C.jpg",
+    "name": "Base Balloons",
+    "symbol": "NANG"
+  },
+  {
+    "address": "0x0d97F261b1e88845184f678e2d1e7a98D9FD38dE",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x0d97F261b1e88845184f678e2d1e7a98D9FD38dE.jpg",
+    "name": "Base God",
+    "symbol": "TYBG"
+  },
+  {
+    "address": "0xDa761A290e01c69325D12D82AC402E5a73D62E81",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xDa761A290e01c69325D12D82AC402E5a73D62E81.jpg",
+    "name": "Base Pro Shops",
+    "symbol": "BPS"
+  },
+  {
+    "address": "0xecaF81Eb42cd30014EB44130b89Bcd6d4Ad98B92",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xecaF81Eb42cd30014EB44130b89Bcd6d4Ad98B92.jpg",
+    "name": "Based Chad",
+    "symbol": "CHAD"
+  },
+  {
+    "address": "0xfEA9DcDc9E23a9068bF557AD5b186675C61d33eA",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xfEA9DcDc9E23a9068bF557AD5b186675C61d33eA.jpg",
+    "name": "Based Shiba Inu",
+    "symbol": "BSHIB"
+  },
+  {
+    "address": "0xB310C7D7428B95aD1B86ba4191704576150429B6",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xB310C7D7428B95aD1B86ba4191704576150429B6.jpg",
+    "name": "BasedBomb",
+    "symbol": "BOMB"
+  },
+  {
     "address": "0xBC45647eA894030a4E9801Ec03479739FA2485F0",
     "chainId": 8453,
     "decimals": 18,
@@ -88,44 +152,12 @@
     "symbol": "BOGE"
   },
   {
-    "address": "0xB310C7D7428B95aD1B86ba4191704576150429B6",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xB310C7D7428B95aD1B86ba4191704576150429B6.jpg",
-    "name": "BasedBomb",
-    "symbol": "BOMB"
-  },
-  {
-    "address": "0x09DeB3CF353186E7A84aBfD7434BF643f77eB686",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0x09DeB3CF353186E7A84aBfD7434BF643f77eB686.jpg",
-    "name": "BASE BOT",
-    "symbol": "BOT"
-  },
-  {
-    "address": "0xDa761A290e01c69325D12D82AC402E5a73D62E81",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xDa761A290e01c69325D12D82AC402E5a73D62E81.jpg",
-    "name": "Base Pro Shops",
-    "symbol": "BPS"
-  },
-  {
     "address": "0x532f27101965dd16442E59d40670FaF5eBB142E4",
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x532f27101965dd16442E59d40670FaF5eBB142E4.jpg",
     "name": "Brett",
     "symbol": "BRETT"
-  },
-  {
-    "address": "0xfEA9DcDc9E23a9068bF557AD5b186675C61d33eA",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xfEA9DcDc9E23a9068bF557AD5b186675C61d33eA.jpg",
-    "name": "Based Shiba Inu",
-    "symbol": "BSHIB"
   },
   {
     "address": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
@@ -136,14 +168,6 @@
     "symbol": "cbETH"
   },
   {
-    "address": "0xecaF81Eb42cd30014EB44130b89Bcd6d4Ad98B92",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xecaF81Eb42cd30014EB44130b89Bcd6d4Ad98B92.jpg",
-    "name": "Based Chad",
-    "symbol": "CHAD"
-  },
-  {
     "address": "0x9e1028F5F1D5eDE59748FFceE5532509976840E0",
     "chainId": 8453,
     "decimals": 18,
@@ -152,20 +176,20 @@
     "symbol": "COMP"
   },
   {
-    "address": "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb.jpg",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI"
-  },
-  {
     "address": "0x85E90a5430AF45776548ADB82eE4cD9E33B08077",
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x85E90a5430AF45776548ADB82eE4cD9E33B08077.jpg",
     "name": "DINO",
     "symbol": "DINO"
+  },
+  {
+    "address": "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb.jpg",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI"
   },
   {
     "address": "0x9D8a9aEc7aDcb2b203D285b9c6F91ABbcDF1D7e4",
@@ -208,14 +232,6 @@
     "symbol": "HAM"
   },
   {
-    "address": "0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3.jpg",
-    "name": "HanChain",
-    "symbol": "HAN"
-  },
-  {
     "address": "0x3e7eF8f50246f725885102E8238CBba33F276747",
     "chainId": 8453,
     "decimals": 18,
@@ -224,20 +240,20 @@
     "symbol": "HANeP"
   },
   {
+    "address": "0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x9e5AAC1Ba1a2e6aEd6b32689DFcF62A509Ca96f3.jpg",
+    "name": "HanChain",
+    "symbol": "HAN"
+  },
+  {
     "address": "0x4d25E94291FE8dcFBfA572cbB2aAa7B755087c91",
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x4d25E94291FE8dcFBfA572cbB2aAa7B755087c91.jpg",
     "name": "High",
     "symbol": "HIGH"
-  },
-  {
-    "address": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea.jpg",
-    "name": "iFARM",
-    "symbol": "iFARM"
   },
   {
     "address": "0xeA930c80d8eac45993d127055E718555e7155fB1",
@@ -256,6 +272,14 @@
     "symbol": "JELLY"
   },
   {
+    "address": "0xbE3111856e4acA828593274eA6872f27968C8DD6",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0xbE3111856e4acA828593274eA6872f27968C8DD6.jpg",
+    "name": "KRAV",
+    "symbol": "KRAV"
+  },
+  {
     "address": "0x64cc19A52f4D631eF5BE07947CABA14aE00c52Eb",
     "chainId": 8453,
     "decimals": 18,
@@ -264,12 +288,12 @@
     "symbol": "KIBBLE"
   },
   {
-    "address": "0xbE3111856e4acA828593274eA6872f27968C8DD6",
+    "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0xbE3111856e4acA828593274eA6872f27968C8DD6.jpg",
-    "name": "KRAV",
-    "symbol": "KRAV"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x6985884C4392D348587B19cb9eAAf157F13271cd.jpg",
+    "name": "LayerZero",
+    "symbol": "ZRO"
   },
   {
     "address": "0x8Fbd0648971d56f1f2c35Fa075Ff5Bc75fb0e39D",
@@ -312,28 +336,12 @@
     "symbol": "MONKE"
   },
   {
-    "address": "0x2CcbEcc47D83eE80e27fd09c8e757B82F1fFad4C",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x2CcbEcc47D83eE80e27fd09c8e757B82F1fFad4C.jpg",
-    "name": "Base Balloons",
-    "symbol": "NANG"
-  },
-  {
     "address": "0xc2106ca72996e49bBADcB836eeC52B765977fd20",
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xc2106ca72996e49bBADcB836eeC52B765977fd20.jpg",
     "name": "NFTEarthOFT",
     "symbol": "NFTE"
-  },
-  {
-    "address": "0x47b464eDB8Dc9BC67b5CD4C9310BB87b773845bD",
-    "chainId": 8453,
-    "decimals": 9,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x47b464eDB8Dc9BC67b5CD4C9310BB87b773845bD.jpg",
-    "name": "Normie",
-    "symbol": "NORMIE"
   },
   {
     "address": "0xB166E8B140D35D9D8226E40C09f757BAC5A4d87d",
@@ -344,12 +352,20 @@
     "symbol": "NPC"
   },
   {
-    "address": "0x137A61B3311E967b0D1e79d5546167C9DC9E6B5B",
+    "address": "0x47b464eDB8Dc9BC67b5CD4C9310BB87b773845bD",
+    "chainId": 8453,
+    "decimals": 9,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x47b464eDB8Dc9BC67b5CD4C9310BB87b773845bD.jpg",
+    "name": "Normie",
+    "symbol": "NORMIE"
+  },
+  {
+    "address": "0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x137A61B3311E967b0D1e79d5546167C9DC9E6B5B.jpg",
-    "name": "Pleasure Coin",
-    "symbol": "NSFW"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea.jpg",
+    "name": "OX Coin",
+    "symbol": "OX"
   },
   {
     "address": "0xC48E605c7b722a57277e087a6170B9E227e5AC0A",
@@ -368,20 +384,28 @@
     "symbol": "OSAK"
   },
   {
-    "address": "0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xba0Dda8762C24dA9487f5FA026a9B64b695A07Ea.jpg",
-    "name": "OX Coin",
-    "symbol": "OX"
-  },
-  {
     "address": "0x40468be13c4388D2AB68a09F56973fa95DB5bca0",
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x40468be13c4388D2AB68a09F56973fa95DB5bca0.jpg",
     "name": "Pizza",
     "symbol": "PIZZA"
+  },
+  {
+    "address": "0x137A61B3311E967b0D1e79d5546167C9DC9E6B5B",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x137A61B3311E967b0D1e79d5546167C9DC9E6B5B.jpg",
+    "name": "Pleasure Coin",
+    "symbol": "NSFW"
+  },
+  {
+    "address": "0x42BAb297f90e6285546F05abdF4C42D8415E9794",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x42BAb297f90e6285546F05abdF4C42D8415E9794.jpg",
+    "name": "Pup Cup",
+    "symbol": "PUPCUP"
   },
   {
     "address": "0xC702b80a1bEBac118cab22Ce6F2978ef59563b3F",
@@ -408,6 +432,14 @@
     "symbol": "Sendit"
   },
   {
+    "address": "0x3124678D62D2aa1f615B54525310fbfDa6DcF7AE",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x3124678D62D2aa1f615B54525310fbfDa6DcF7AE.jpg",
+    "name": "Sensay",
+    "symbol": "SNSY"
+  },
+  {
     "address": "0xD1917629B3E6A72E6772Aab5dBe58Eb7FA3C2F33",
     "chainId": 8453,
     "decimals": 18,
@@ -424,14 +456,6 @@
     "symbol": "SMUDCAT"
   },
   {
-    "address": "0x3124678D62D2aa1f615B54525310fbfDa6DcF7AE",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x3124678D62D2aa1f615B54525310fbfDa6DcF7AE.jpg",
-    "name": "Sensay",
-    "symbol": "SNSY"
-  },
-  {
     "address": "0x7D49a065D17d6d4a55dc13649901fdBB98B2AFBA",
     "chainId": 8453,
     "decimals": 18,
@@ -440,12 +464,12 @@
     "symbol": "SUSHI"
   },
   {
-    "address": "0xb8D98a102b0079B69FFbc760C8d857A31653e56e",
+    "address": "0xf7C1CEfCf7E1dd8161e00099facD3E1Db9e528ee",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xb8D98a102b0079B69FFbc760C8d857A31653e56e.jpg",
-    "name": "toby",
-    "symbol": "toby"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xf7C1CEfCf7E1dd8161e00099facD3E1Db9e528ee.jpg",
+    "name": "TOWER",
+    "symbol": "TOWER"
   },
   {
     "address": "0x8544FE9D190fD7EC52860abBf45088E81Ee24a8c",
@@ -462,22 +486,6 @@
     "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xAC1Bd2486aAf3B5C0fc3Fd868558b082a531B2B4.jpg",
     "name": "Toshi",
     "symbol": "TOSHI"
-  },
-  {
-    "address": "0xf7C1CEfCf7E1dd8161e00099facD3E1Db9e528ee",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xf7C1CEfCf7E1dd8161e00099facD3E1Db9e528ee.jpg",
-    "name": "TOWER",
-    "symbol": "TOWER"
-  },
-  {
-    "address": "0x0d97F261b1e88845184f678e2d1e7a98D9FD38dE",
-    "chainId": 8453,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x0d97F261b1e88845184f678e2d1e7a98D9FD38dE.jpg",
-    "name": "Base God",
-    "symbol": "TYBG"
   },
   {
     "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
@@ -544,19 +552,19 @@
     "symbol": "YOU"
   },
   {
-    "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+    "address": "0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0x6985884C4392D348587B19cb9eAAf157F13271cd.jpg",
-    "name": "LayerZero",
-    "symbol": "ZRO"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xE7798f023fC62146e8Aa1b36Da45fb70855a77Ea.jpg",
+    "name": "iFARM",
+    "symbol": "iFARM"
   },
   {
-    "address": "0x3bB4445D30AC020a84c1b5A8A2C6248ebC9779D0",
+    "address": "0xb8D98a102b0079B69FFbc760C8d857A31653e56e",
     "chainId": 8453,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/network/base/0x3bB4445D30AC020a84c1b5A8A2C6248ebC9779D0.jpg",
-    "name": "0x Protocol Token",
-    "symbol": "ZRX"
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/network/base/0xb8D98a102b0079B69FFbc760C8d857A31653e56e.jpg",
+    "name": "toby",
+    "symbol": "toby"
   }
 ]


### PR DESCRIPTION
## Add PUPCUP (Pup Cup) to Base token list

| Field | Value |
|---|---|
| Name | Pup Cup |
| Symbol | PUPCUP |
| Chain ID | 8453 (Base) |
| Address | `0x42BAb297f90e6285546F05abdF4C42D8415E9794` |
| Decimals | 18 |
| Website | https://theanvil.xyz |
| Basescan | https://basescan.org/token/0x42bab297f90e6285546f05abdf4c42d8415e9794 |

- Source verified on Basescan ✅
- 0% tax (Honeypot.is) ✅
- LP locked 2027 ✅
- Active Uniswap V3 pool on Base ✅